### PR TITLE
(fix) [LC-I419] Remove tstamp from appup template

### DIFF
--- a/priv/templates/appup.tpl
+++ b/priv/templates/appup.tpl
@@ -1,4 +1,4 @@
-%% appup generated for {{app}} by rebar3_appup_plugin ({{{now}}})
+%% appup generated for {{app}} by rebar3_appup_plugin
 { "{{{new_vsn}}}",
     [{ "{{{old_vsn}}}",
         {{{upgrade_instructions}}} }],

--- a/src/rebar3_appup_generate.erl
+++ b/src/rebar3_appup_generate.erl
@@ -34,7 +34,7 @@
 
 -define(PRIV_DIR, "priv").
 -define(APPUP_TEMPLATE, "templates/appup.tpl").
--define(APPUPFILEFORMAT, "%% appup generated for ~p by rebar3_appup_plugin (~p)~n"
+-define(APPUPFILEFORMAT, "%% appup generated for ~p by rebar3_appup_plugin~n"
         "{~p,\n\t[{~p, \n\t\t~p}], \n\t[{~p, \n\t\t~p}\n]}.~n").
 -define(DEFAULT_RELEASE_DIR, "rel").
 -define(DEFAULT_PRE_PURGE, brutal_purge).
@@ -449,7 +449,6 @@ write_appup(App, OldVer, NewVer, TargetDir,
     %% write each of the .appup files
     lists:foreach(fun(AppUpFile) ->
                     AppupCtx = [{"app", App},
-                                {"now", rebar3_appup_utils:now_str()},
                                 {"new_vsn", NewVer},
                                 {"old_vsn", OldVer},
                                 {"upgrade_instructions",
@@ -750,7 +749,7 @@ get_release_name(State) ->
 %% Example:
 %%
 %% Generated relapp.appup
-%% %% appup generated for relapp by rebar3_appup_plugin (2018/01/10 14:35:19)
+%% %% appup generated for relapp by rebar3_appup_plugin
 %% {"1.0.34",
 %%   [{ "1.0.33",
 %%     [{apply,{io,format,["Upgrading is in progress..."]}}]}],
@@ -786,7 +785,7 @@ get_release_name(State) ->
 %%
 %% The final relapp.appup file after merging the pre and post contents:
 %%
-%% %% appup generated for relapp by rebar3_appup_plugin (2018/01/10 14:35:19)
+%% %% appup generated for relapp by rebar3_appup_plugin
 %% {"1.0.34",
 %%   [{"1.0.33",
 %%     [{apply,{io,format,["Upgrading started from 1.* to 1.0.34"]}},

--- a/src/rebar3_appup_utils.erl
+++ b/src/rebar3_appup_utils.erl
@@ -23,7 +23,6 @@
          make_proplist/2,
          find_files/3,
          find_files_by_ext/2, find_files_by_ext/3,
-         now_str/0,
          get_sub_dirs/1,
          appup_plugin_appinfo/1,
          find_app_info/2,
@@ -78,12 +77,6 @@ find_files_by_ext(Dir, Ext, Recursive) ->
                 end,
     ExtRe = "^[^._].*" ++ EscapeDot ++ Ext ++ [$$],
     find_files(Dir, ExtRe, Recursive).
-
-%% @spec now_str() -> [any()].
-now_str() ->
-    {{Year, Month, Day}, {Hour, Minute, Second}} = calendar:local_time(),
-    lists:flatten(io_lib:format("~4b/~2..0b/~2..0b ~2..0b:~2..0b:~2..0b",
-                                [Year, Month, Day, Hour, Minute, Second])).
 
 %% @spec get_sub_dirs(atom() | binary() | [atom() | [any()] | char()]) -> [any()].
 get_sub_dirs(Dir) ->


### PR DESCRIPTION
Remove timestamp from generated appup files to allow for more deterministic commits of files in git